### PR TITLE
Add JDBCCertRecordStoreStatusChecker

### DIFF
--- a/servers/zts/src/main/java/com/yahoo/athenz/zts/cert/impl/JDBCCertRecordStoreStatusChecker.java
+++ b/servers/zts/src/main/java/com/yahoo/athenz/zts/cert/impl/JDBCCertRecordStoreStatusChecker.java
@@ -1,0 +1,45 @@
+/*
+ *  Copyright 2020 Verizon Media
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.yahoo.athenz.zts.cert.impl;
+
+import com.yahoo.athenz.common.server.cert.CertRecordStoreConnection;
+import com.yahoo.athenz.common.server.status.StatusCheckException;
+import com.yahoo.athenz.common.server.status.StatusChecker;
+import com.yahoo.athenz.zts.ResourceException;
+
+public class JDBCCertRecordStoreStatusChecker implements StatusChecker {
+
+    private JDBCCertRecordStore jdbcCertRecordStore;
+
+    JDBCCertRecordStoreStatusChecker(JDBCCertRecordStore jdbcCertRecordStore) {
+        this.jdbcCertRecordStore = jdbcCertRecordStore;
+    }
+
+    @Override
+    public void check() throws StatusCheckException {
+        CertRecordStoreConnection certRecordStoreConnection = null;
+        try {
+            certRecordStoreConnection = jdbcCertRecordStore.getConnection();
+        } catch (ResourceException e) {
+            throw new StatusCheckException(e);
+        } finally {
+            if (certRecordStoreConnection != null) {
+                certRecordStoreConnection.close();
+            }
+        }
+    }
+}

--- a/servers/zts/src/main/java/com/yahoo/athenz/zts/cert/impl/JDBCCertRecordStoreStatusChecker.java
+++ b/servers/zts/src/main/java/com/yahoo/athenz/zts/cert/impl/JDBCCertRecordStoreStatusChecker.java
@@ -19,7 +19,6 @@ package com.yahoo.athenz.zts.cert.impl;
 import com.yahoo.athenz.common.server.cert.CertRecordStoreConnection;
 import com.yahoo.athenz.common.server.status.StatusCheckException;
 import com.yahoo.athenz.common.server.status.StatusChecker;
-import com.yahoo.athenz.zts.ResourceException;
 
 public class JDBCCertRecordStoreStatusChecker implements StatusChecker {
 

--- a/servers/zts/src/main/java/com/yahoo/athenz/zts/cert/impl/JDBCCertRecordStoreStatusChecker.java
+++ b/servers/zts/src/main/java/com/yahoo/athenz/zts/cert/impl/JDBCCertRecordStoreStatusChecker.java
@@ -32,7 +32,7 @@ public class JDBCCertRecordStoreStatusChecker implements StatusChecker {
     @Override
     public void check() throws StatusCheckException {
         try (CertRecordStoreConnection certRecordStoreConnection = jdbcCertRecordStore.getConnection()) {
-        } catch (ResourceException e) {
+        } catch (Throwable e) {
             throw new StatusCheckException(e);
         }
     }

--- a/servers/zts/src/main/java/com/yahoo/athenz/zts/cert/impl/JDBCCertRecordStoreStatusChecker.java
+++ b/servers/zts/src/main/java/com/yahoo/athenz/zts/cert/impl/JDBCCertRecordStoreStatusChecker.java
@@ -31,15 +31,9 @@ public class JDBCCertRecordStoreStatusChecker implements StatusChecker {
 
     @Override
     public void check() throws StatusCheckException {
-        CertRecordStoreConnection certRecordStoreConnection = null;
-        try {
-            certRecordStoreConnection = jdbcCertRecordStore.getConnection();
+        try (CertRecordStoreConnection certRecordStoreConnection = jdbcCertRecordStore.getConnection()) {
         } catch (ResourceException e) {
             throw new StatusCheckException(e);
-        } finally {
-            if (certRecordStoreConnection != null) {
-                certRecordStoreConnection.close();
-            }
         }
     }
 }

--- a/servers/zts/src/main/java/com/yahoo/athenz/zts/cert/impl/JDBCCertRecordStoreStatusCheckerFactory.java
+++ b/servers/zts/src/main/java/com/yahoo/athenz/zts/cert/impl/JDBCCertRecordStoreStatusCheckerFactory.java
@@ -1,0 +1,55 @@
+/*
+ *  Copyright 2020 Verizon Media
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.yahoo.athenz.zts.cert.impl;
+
+import com.yahoo.athenz.auth.PrivateKeyStore;
+import com.yahoo.athenz.auth.PrivateKeyStoreFactory;
+import com.yahoo.athenz.common.server.cert.CertRecordStore;
+import com.yahoo.athenz.common.server.status.StatusChecker;
+import com.yahoo.athenz.common.server.status.StatusCheckerFactory;
+import com.yahoo.athenz.zts.ZTSConsts;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class JDBCCertRecordStoreStatusCheckerFactory implements StatusCheckerFactory {
+    private static final Logger LOGGER = LoggerFactory.getLogger(JDBCCertRecordStoreStatusCheckerFactory.class);
+    private final PrivateKeyStore keyStore = getKeyStore();
+
+    @Override
+    public StatusChecker create() {
+        CertRecordStore certRecordStore = new JDBCCertRecordStoreFactory().create(keyStore);
+        return new JDBCCertRecordStoreStatusChecker((JDBCCertRecordStore) certRecordStore);
+    }
+
+    private PrivateKeyStore getKeyStore() {
+        final String pkeyFactoryClass = System.getProperty(ZTSConsts.ZTS_PROP_PRIVATE_KEY_STORE_FACTORY_CLASS,
+                ZTSConsts.ZTS_PKEY_STORE_FACTORY_CLASS);
+        PrivateKeyStoreFactory pkeyFactory;
+        try {
+            pkeyFactory = (PrivateKeyStoreFactory) Class.forName(pkeyFactoryClass).newInstance();
+        } catch (InstantiationException | IllegalAccessException | ClassNotFoundException e) {
+            LOGGER.error("Invalid PrivateKeyStoreFactory class: " + pkeyFactoryClass
+                    + " error: " + e.getMessage());
+            throw new IllegalArgumentException("Invalid private key store");
+        }
+
+        // extract the private key for our service - we're going to ask for our algorithm
+        // specific keys and then if neither one is provided our generic one.
+
+        return pkeyFactory.create();
+    }
+}

--- a/servers/zts/src/test/java/com/yahoo/athenz/zts/cert/impl/JDBCCertRecordStoreStatusCheckerFactoryTest.java
+++ b/servers/zts/src/test/java/com/yahoo/athenz/zts/cert/impl/JDBCCertRecordStoreStatusCheckerFactoryTest.java
@@ -1,0 +1,59 @@
+/*
+ *  Copyright 2020 Verizon Media
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.yahoo.athenz.zts.cert.impl;
+
+import com.yahoo.athenz.common.server.status.StatusChecker;
+import com.yahoo.athenz.zts.ZTSConsts;
+import org.testng.annotations.Test;
+
+import static org.testng.AssertJUnit.*;
+
+public class JDBCCertRecordStoreStatusCheckerFactoryTest {
+
+    @Test
+    public void testCreate() {
+        System.getProperty(ZTSConsts.ZTS_PROP_PRIVATE_KEY_STORE_FACTORY_CLASS,
+                ZTSConsts.ZTS_PKEY_STORE_FACTORY_CLASS);
+        System.setProperty(ZTSConsts.ZTS_PROP_CERT_JDBC_STORE, "jdbc:mysql://localhost");
+        System.setProperty(ZTSConsts.ZTS_PROP_CERT_JDBC_USER, "user");
+        System.setProperty(ZTSConsts.ZTS_PROP_CERT_JDBC_PASSWORD, "password");
+
+        JDBCCertRecordStoreStatusCheckerFactory jdbcCertRecordStoreStatusCheckerFactory =
+                new JDBCCertRecordStoreStatusCheckerFactory();
+        StatusChecker statusChecker = jdbcCertRecordStoreStatusCheckerFactory.create();
+        assertNotNull(statusChecker);
+
+        System.clearProperty(ZTSConsts.ZTS_PROP_PRIVATE_KEY_STORE_FACTORY_CLASS);
+        System.clearProperty(ZTSConsts.ZTS_PROP_CERT_JDBC_STORE);
+        System.clearProperty(ZTSConsts.ZTS_PROP_CERT_JDBC_USER);
+        System.clearProperty(ZTSConsts.ZTS_PROP_CERT_JDBC_PASSWORD);
+    }
+
+    @Test
+    public void testBadKeyStoreClass() {
+        System.setProperty(ZTSConsts.ZTS_PROP_PRIVATE_KEY_STORE_FACTORY_CLASS, "unknownClassName");
+        try {
+            new JDBCCertRecordStoreStatusCheckerFactory();
+
+            fail();
+        } catch (IllegalArgumentException ex) {
+            assertEquals(ex.getMessage(), "Invalid private key store");
+        }
+
+        System.clearProperty(ZTSConsts.ZTS_PROP_PRIVATE_KEY_STORE_FACTORY_CLASS);
+    }
+}

--- a/servers/zts/src/test/java/com/yahoo/athenz/zts/cert/impl/JDBCCertRecordStoreStatusCheckerTest.java
+++ b/servers/zts/src/test/java/com/yahoo/athenz/zts/cert/impl/JDBCCertRecordStoreStatusCheckerTest.java
@@ -1,0 +1,61 @@
+/*
+ *  Copyright 2020 Verizon Media
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.yahoo.athenz.zts.cert.impl;
+
+import com.yahoo.athenz.common.server.cert.CertRecordStoreConnection;
+import com.yahoo.athenz.common.server.status.StatusCheckException;
+import com.yahoo.athenz.zts.ResourceException;
+import org.mockito.Mockito;
+import org.testng.annotations.Test;
+
+import static org.testng.AssertJUnit.assertEquals;
+import static org.testng.AssertJUnit.fail;
+
+public class JDBCCertRecordStoreStatusCheckerTest {
+
+    @Test
+    public void testCheck() throws StatusCheckException {
+        JDBCCertRecordStore jdbcCertRecordStore = Mockito.mock(JDBCCertRecordStore.class);
+        CertRecordStoreConnection certRecordStoreConnection = Mockito.mock(CertRecordStoreConnection.class);
+        Mockito.when(jdbcCertRecordStore.getConnection()).thenReturn(certRecordStoreConnection);
+
+        JDBCCertRecordStoreStatusChecker jdbcCertRecordStoreStatusChecker =
+                new JDBCCertRecordStoreStatusChecker(jdbcCertRecordStore);
+        jdbcCertRecordStoreStatusChecker.check();
+
+        Mockito.verify(jdbcCertRecordStore, Mockito.times(1)).getConnection();
+        Mockito.verify(certRecordStoreConnection, Mockito.times(1)).close();
+    }
+
+    @Test
+    public void testCheckNoDBConnection() {
+        JDBCCertRecordStore jdbcCertRecordStore = Mockito.mock(JDBCCertRecordStore.class);
+        Mockito.when(jdbcCertRecordStore.getConnection()).thenThrow(new ResourceException(503));
+
+        JDBCCertRecordStoreStatusChecker jdbcCertRecordStoreStatusChecker =
+                new JDBCCertRecordStoreStatusChecker(jdbcCertRecordStore);
+        try {
+            jdbcCertRecordStoreStatusChecker.check();
+            fail();
+        } catch (StatusCheckException ex) {
+            assertEquals(500, ex.getCode());
+            assertEquals("ResourceException (503): {code: 503, message: \"Service Unavailable\"}", ex.getMsg());
+        }
+
+        Mockito.verify(jdbcCertRecordStore, Mockito.times(1)).getConnection();
+    }
+}


### PR DESCRIPTION
## Motivation
We create a StatusChecker class for JDBCCertRecordStore and want to use it as a health check for the ZTS.

## Behavior this change
1. Set `athenz.zts.status_checker_factory_class=com.yahoo.athenz.zts.cert.impl.JDBCCertRecordStoreStatusCheckerFactory` in zts.properties.
2. Start the ZTS and MySQL.
3. Run `curl -k https://localhost:8443/zts/v1/status -v`, The response is below.
```
{"code":200,"message":"OK"}
```
4. Stop the MySQL.
5. Run `curl -k https://localhost:8443/zts/v1/status -v`, The response is below.
```
{"code":500,"message":"ResourceException (503): Communications link failure\n\nThe last packet sent successfully to the server was 0 milliseconds ago. The driver has not received any packets from the server."}
```

------
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.